### PR TITLE
Add a LongIterator interface to favor primitives.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,18 @@
   <packaging>jar</packaging>
   <version>1.0.4-SNAPSHOT</version>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
   <!-- ===================================================================== -->
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.2</version>
-      <optional>true</optional>
+      <version>4.11</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -24,7 +29,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -35,11 +40,21 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
       
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
+        <version>2.9.1</version>
         <executions>
           <execution>
             <id>attach-javadoc</id>

--- a/src/main/java/org/cliffc/high_scale_lib/LongIterator.java
+++ b/src/main/java/org/cliffc/high_scale_lib/LongIterator.java
@@ -1,0 +1,16 @@
+package org.cliffc.high_scale_lib;
+
+import java.util.Iterator;
+
+/**
+ * An extension of the standard {@link Iterator} interface which provides the {@link #nextLong()} method to avoid
+ * auto-boxing of results as they are returned.
+ * */
+public interface LongIterator extends Iterator<Long> {
+    /**
+     * Returns the next long value without auto-boxing. Using this is preferred to {@link #next()}.
+     *
+     * @return The next long value.
+     */
+    long nextLong();
+}

--- a/src/main/java/org/cliffc/high_scale_lib/NonBlockingHashMapLong.java
+++ b/src/main/java/org/cliffc/high_scale_lib/NonBlockingHashMapLong.java
@@ -1059,7 +1059,7 @@ public class NonBlockingHashMapLong<TypeV>
   /** A class which implements the {@link Iterator} and {@link Enumeration}
    *  interfaces, generified to the {@link Long} class and supporting a
    *  <strong>non-auto-boxing</strong> {@link #nextLong} function.  */
-  public class IteratorLong implements Iterator<Long>, Enumeration<Long> {
+  public class IteratorLong implements LongIterator, Enumeration<Long> {
     private final SnapshotV _ss;
     /** A new IteratorLong */
     public IteratorLong() { _ss = new SnapshotV(); }

--- a/src/test/java/org/cliffc/high_scale_lib/NonBlockingHashMapLongTest.java
+++ b/src/test/java/org/cliffc/high_scale_lib/NonBlockingHashMapLongTest.java
@@ -505,4 +505,17 @@ public class NonBlockingHashMapLongTest extends TestCase {
     assertEquals("values().iterator() count", itemCount, iteratorCount);
   }
 
+  public void testLongIterator() {
+    NonBlockingHashMapLong<String> map = new NonBlockingHashMapLong<String>();
+    map.put(1L, "abc");
+    map.put(2L, "def");
+    LongIterator it = (LongIterator) map.keySet().iterator();
+    List<Long> keys = new ArrayList<Long>(2);
+    while (it.hasNext()) {
+      keys.add(it.nextLong());
+    }
+    Collections.sort(keys);
+    assertEquals(Arrays.asList(1L, 2L), keys);
+  }
+
 }


### PR DESCRIPTION
The current IteratorLong class is a nested class in
NonBlockingHashMapLong, which means to iterate over the keys without
auto boxing the casting can get awkward. This adds an interface
LongIterator which the returned iterator from keySet().iterator() can be
cast to safely. This also cleans up the Maven POM file and adds a simple
test for the iterator.
