### PR TITLE
Avoid additional auto-boxing in NonBlockingSetInt.

### DIFF
--- a/src/main/java/java/util/Hashtable.java
+++ b/src/main/java/java/util/Hashtable.java
@@ -26,8 +26,8 @@ import  org.cliffc.high_scale_lib.NonBlockingHashtable;
  *
  * @since 1.5
  * @author Cliff Click
- * @param <TypeK> the type of keys maintained by this map
- * @param <TypeV> the type of mapped values
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values
  */
 public class Hashtable<K, V> extends NonBlockingHashtable<K, V> {
   /** use serialVersionUID from JDK 1.0.2 for interoperability */

--- a/src/main/java/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/main/java/java/util/concurrent/ConcurrentHashMap.java
@@ -9,14 +9,14 @@ import  org.cliffc.high_scale_lib.NonBlockingHashMap;
 
 /**
  * A plug-in replacement for JDK1.5 {@link java.util.concurrent.ConcurrentHashMap}.  
- * This version is based on {@link * org.cliffc.high_scale_lib.NonBlockingHashMap}.  
+ * This version is based on {@link org.cliffc.high_scale_lib.NonBlockingHashMap}.
  * This solution should be completely compatible, including the serialized
  * forms and all multi-threaded ordering guarantees.
  *
  * @since 1.5
  * @author Cliff Click
- * @param <TypeK> the type of keys maintained by this map
- * @param <TypeV> the type of mapped values
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values
  */
 public class ConcurrentHashMap<K, V> extends NonBlockingHashMap<K, V> {
   private static final long serialVersionUID = 7249069246763182397L;

--- a/src/main/java/org/cliffc/high_scale_lib/IntIterator.java
+++ b/src/main/java/org/cliffc/high_scale_lib/IntIterator.java
@@ -1,6 +1,25 @@
 package org.cliffc.high_scale_lib;
 
+/**
+ * An iterator optimized for primitive collections which avoids auto-boxing on {@link #next()}.
+ */
 public interface IntIterator {
-	public int next();
-	public boolean hasNext();
+    /**
+     * Identical to {@link java.util.Iterator#next()} but avoids auto-boxing.
+     *
+     * @return The next int in the collection.
+     */
+    int next();
+
+    /**
+     * Identical to {@link java.util.Iterator#hasNext()}.
+     *
+     * @return True if the iterator has more elements.
+     */
+    boolean hasNext();
+
+    /**
+     * Identical to {@link java.util.Iterator#remove()}.
+     */
+    void remove();
 }

--- a/src/main/java/org/cliffc/high_scale_lib/NonBlockingHashMap.java
+++ b/src/main/java/org/cliffc/high_scale_lib/NonBlockingHashMap.java
@@ -17,7 +17,7 @@ import sun.misc.Unsafe;
  * with better scaling properties and generally lower costs to mutate the Map.
  * It provides identical correctness properties as ConcurrentHashMap.  All
  * operations are non-blocking and multi-thread safe, including all update
- * operations.  {@link NonBlockingHashMap} scales substatially better than
+ * operations.  {@link NonBlockingHashMap} scales substantially better than
  * {@link java.util.concurrent.ConcurrentHashMap} for high update rates, even with a
  * large concurrency factor.  Scaling is linear up to 768 CPUs on a 768-CPU
  * Azul box, even with 100% updates or 100% reads or any fraction in-between.


### PR DESCRIPTION
Overloads addAll(), removeAll(), containsAll(), retainAll(), hashCode(),
and toString() to avoid auto-boxing. Fixes some miscellaneous JavaDoc
issues and other small code changes.
